### PR TITLE
Fix crash happening if a player changes world before PlayerJoinEvent is called

### DIFF
--- a/src/Ifera/ScoreHud/EventListener.php
+++ b/src/Ifera/ScoreHud/EventListener.php
@@ -60,7 +60,7 @@ class EventListener implements Listener{
 
 		$player = $event->getEntity();
 
-		if(!$player instanceof Player){
+		if(!$player instanceof Player or !$player->spawned){
 			return;
 		}
 


### PR DESCRIPTION
This happened to me because of an always-spawn plugin teleporting the player in PlayerLoginEvent